### PR TITLE
Added python argparse module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Writing and maintianing this is not fun and takes time. Luckily there are librar
 
 
 Go: https://github.com/spf13/cobra  
-Python: TODO
+Python: https://docs.python.org/3/library/argparse.html
 
 ## Minimize the number of dependencies
 


### PR DESCRIPTION
It's included by default on python from 3.2
For people with below python version: https://github.com/ThomasWaldmann/argparse